### PR TITLE
Image gallery expanded

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,6 @@ module.exports = {
     // 'no-console': 'off',
     'react/prop-types': ['off'],
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
-    ignoreReadBeforeAssign: false,
+    // ignoreReadBeforeAssign: false,
   },
 };

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -16,7 +16,7 @@ const App = () => {
       .then((results) => {
         // setAllProducts(results.data);
 
-        setCurrentProduct(results.data[2]);
+        setCurrentProduct(results.data[3]);
 
       })
       .catch((err) => console.log(err));

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -15,9 +15,7 @@ const App = () => {
     axios.get('http://localhost:3000/api/allproducts')
       .then((results) => {
         // setAllProducts(results.data);
-
         setCurrentProduct(results.data[3]);
-
       })
       .catch((err) => console.log(err));
   };

--- a/client/components/Overview/Overview.jsx
+++ b/client/components/Overview/Overview.jsx
@@ -6,28 +6,57 @@ import Sizes from './components/Sizes';
 import Quantity from './components/Quantity';
 import AddToCart from './components/AddToCart';
 import ImageGallery from './components/ImageGallery/ImageGallery';
+import ImageGalleryExpand from './components/ImageGalleryExpand/ImageGalleryExpand';
 
 const Overview = ({ currentProduct }) => {
   //  Current selection of items to be used in specific
   //  components that rely on others existing e.g. size depends on current style
-  const [currentStyle, setCurrentStyle] = useState({});
+  const [currentStyle, setCurrentStyle] = useState(null);
   const [currentSize, setCurrentSize] = useState(null);
   const [currentQuantity, setCurrentQuantity] = useState();
   const [addToCartNoSize, setAddToCartNoSize] = useState(false);
   const [value, setValue] = useState('DEFAULT');
-  const [imageArray, setImageArray] = useState([]);
+  // const [imageArray, setImageArray] = useState([]);
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const [thumbSplitArr, setThumbSplitArr] = useState([]);
   const [thumbDisplayArr, setThumbDisplayArr] = useState(0);
+  const [overviewModal, setOverviewModal] = useState(false);
 
   //  on user changing style in image gallery by clicking the arrows update the current style
-  useEffect(() => setCurrentStyle(imageArray[currentImageIndex]), [currentImageIndex]);
   useEffect(() => setThumbDisplayArr(Math.floor(currentImageIndex / 7)), [currentImageIndex]);
+
+  useEffect(() => setCurrentImageIndex(0), [currentStyle]);
+
+  useEffect(() => {
+    if (currentStyle) {
+      setCurrentImageIndex(0);
+      // //  create an array with all styles (not in rows of 4)
+      // setImageArray(currentStyle.photos);
+      //  set the number of rows for thumbnail on main image
+      const numberOfRows = Math.ceil(currentStyle.photos.length / 7);
+      //  split the thumbnails into n arrays of length 7
+      setThumbSplitArr([...Array(numberOfRows)]
+        .map((row, idx) => currentStyle.photos
+          .slice(idx * 7, idx * 7 + 7)));
+    }
+  }, [currentStyle]);
 
   //  render each component and certain components will not render
   //  unless the data required is present (used to save some time);
   return (
     <div id="Overview">
+      {(overviewModal === true) ? (
+        <ImageGalleryExpand
+          setCurrentStyle={setCurrentStyle}
+          setCurrentImageIndex={setCurrentImageIndex}
+          currentImageIndex={currentImageIndex}
+          currentStyle={currentStyle}
+          thumbDisplayArr={thumbDisplayArr}
+          thumbSplitArr={thumbSplitArr}
+          setThumbDisplayArr={setThumbDisplayArr}
+          setOverviewModal={setOverviewModal}
+        />
+      ) : null}
       {(currentStyle) ? (
         <ProductInformation
           currentProduct={currentProduct}
@@ -44,7 +73,6 @@ const Overview = ({ currentProduct }) => {
           setCurrentQuantity={setCurrentQuantity}
           setAddToCartNoSize={setAddToCartNoSize}
           setValue={setValue}
-          setImageArray={setImageArray}
           setThumbSplitArr={setThumbSplitArr}
           setCurrentImageIndex={setCurrentImageIndex}
         />
@@ -79,9 +107,8 @@ const Overview = ({ currentProduct }) => {
         />
       )
         : null }
-      {(currentStyle && imageArray.length > 0) ? (
+      {(currentStyle) ? (
         <ImageGallery
-          imageArray={imageArray}
           setCurrentStyle={setCurrentStyle}
           setCurrentImageIndex={setCurrentImageIndex}
           currentImageIndex={currentImageIndex}
@@ -89,6 +116,7 @@ const Overview = ({ currentProduct }) => {
           thumbDisplayArr={thumbDisplayArr}
           thumbSplitArr={thumbSplitArr}
           setThumbDisplayArr={setThumbDisplayArr}
+          setOverviewModal={setOverviewModal}
         />
       ) : null}
     </div>

--- a/client/components/Overview/components/ImageGallery/ImageGallery.jsx
+++ b/client/components/Overview/components/ImageGallery/ImageGallery.jsx
@@ -3,12 +3,11 @@ import '../../styles/ImageGalleryStyles.css';
 import ImageGalleryImageSlide from './ImageGalleryImageSlide';
 
 const ImageGallery = ({
-  imageArray, currentImageIndex, setCurrentImageIndex, currentStyle,
-  setCurrentStyle, thumbSplitArr, thumbDisplayArr, setThumbDisplayArr,
+  currentImageIndex, setCurrentImageIndex, currentStyle,
+  setCurrentStyle, thumbSplitArr, thumbDisplayArr, setThumbDisplayArr, setOverviewModal,
 }) => (
   <div id="imagegallery-container">
     <ImageGalleryImageSlide
-      imageArray={imageArray}
       currentImageIndex={currentImageIndex}
       setCurrentImageIndex={setCurrentImageIndex}
       currentStyle={currentStyle}
@@ -16,6 +15,7 @@ const ImageGallery = ({
       thumbDisplayArr={thumbDisplayArr}
       thumbSplitArr={thumbSplitArr}
       setThumbDisplayArr={setThumbDisplayArr}
+      setOverviewModal={setOverviewModal}
     />
   </div>
 );

--- a/client/components/Overview/components/ImageGallery/ImageGalleryImageSlide.jsx
+++ b/client/components/Overview/components/ImageGallery/ImageGalleryImageSlide.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable react/no-array-index-key */
 import React from 'react';
 import noImage from '../../../../../public/static/noimage.jpg';
@@ -6,40 +8,46 @@ import ImageGalleryArrows from './ImageGalleryArrows';
 import ImageGalleryThumbnail from './ImageGalleryThumbnail';
 
 const ImageGalleryImageSlide = ({
-  imageArray, setCurrentImageIndex, currentImageIndex, currentStyle, setCurrentStyle,
-  thumbSplitArr, thumbDisplayArr, setThumbDisplayArr,
+  setCurrentImageIndex, currentImageIndex, currentStyle, setCurrentStyle,
+  thumbSplitArr, thumbDisplayArr, setThumbDisplayArr, setOverviewModal,
 }) => (
   <div id="imagegallery-mainimage-container">
-    <ImageGalleryArrows
-      currentImageIndex={currentImageIndex}
-      setCurrentImageIndex={setCurrentImageIndex}
-      imageArray={imageArray}
-    />
-    <ImageGalleryThumbnail
-      imageArray={imageArray}
-      currentImageIndex={currentImageIndex}
-      setCurrentImageIndex={setCurrentImageIndex}
-      setCurrentStyle={setCurrentStyle}
-      thumbDisplayArr={thumbDisplayArr}
-      thumbSplitArr={thumbSplitArr}
-      setThumbDisplayArr={setThumbDisplayArr}
-    />
-    {imageArray.map((style, idx) => (
+    {thumbSplitArr.length > 0 ? (
+      <>
+        <ImageGalleryArrows
+          currentImageIndex={currentImageIndex}
+          setCurrentImageIndex={setCurrentImageIndex}
+          currentStyle={currentStyle}
+        />
+        <ImageGalleryThumbnail
+          currentStyle={currentStyle}
+          currentImageIndex={currentImageIndex}
+          setCurrentImageIndex={setCurrentImageIndex}
+          setCurrentStyle={setCurrentStyle}
+          thumbDisplayArr={thumbDisplayArr}
+          thumbSplitArr={thumbSplitArr}
+          setThumbDisplayArr={setThumbDisplayArr}
+        />
+      </>
+    ) : null }
+    {currentStyle.photos.map((style, idx) => (
       <React.Fragment key={idx}>
-        {(style.photos[0].url !== null)
+        {(style.url !== null)
           ? (
             <div
               id="imagegallery-slide-image"
-              key={style.photos[0].url + idx}
-              style={currentStyle === style ? { backgroundImage: `url(${style.photos[0].url})`, opacity: 1, zIndex: 2 } : { backgroundImage: `url(${style.photos[0].url})`, opacity: 0 }}
+              key={idx}
+              style={currentImageIndex === idx ? { backgroundImage: `url(${style.url})`, opacity: 1, zIndex: 2 } : { backgroundImage: `url(${style.url})`, opacity: 0 }}
               alt=""
+              onClick={() => setOverviewModal(true)}
             />
           ) : (
             <div
-              key={style.photos[0].url + idx}
+              key={idx}
               id="imagegallery-slide-image"
               style={currentStyle === style ? { backgroundImage: `url(${noImage})`, opacity: 1, zIndex: 2 } : { backgroundImage: `url(${noImage})`, opacity: 0 }}
               alt=""
+              onClick={() => setOverviewModal(true)}
             />
           ) }
       </React.Fragment>

--- a/client/components/Overview/components/ImageGallery/ImageGalleryImageSlide.jsx
+++ b/client/components/Overview/components/ImageGallery/ImageGalleryImageSlide.jsx
@@ -25,7 +25,7 @@ const ImageGalleryImageSlide = ({
       setThumbDisplayArr={setThumbDisplayArr}
     />
     {imageArray.map((style, idx) => (
-      <>
+      <React.Fragment key={idx}>
         {(style.photos[0].url !== null)
           ? (
             <div
@@ -42,7 +42,7 @@ const ImageGalleryImageSlide = ({
               alt=""
             />
           ) }
-      </>
+      </React.Fragment>
     ))}
   </div>
 );

--- a/client/components/Overview/components/ImageGallery/ImageGalleryThumbnail.jsx
+++ b/client/components/Overview/components/ImageGallery/ImageGalleryThumbnail.jsx
@@ -7,8 +7,8 @@ import noImage from '../../../../../public/static/noimage.jpg';
 import '../../styles/ImageGalleryStyles.css';
 
 const ImageGalleryThumbnail = ({
-  currentImageIndex, setCurrentImageIndex, imageArray, setCurrentStyle,
-  thumbSplitArr, thumbDisplayArr, setThumbDisplayArr,
+  currentImageIndex, setCurrentImageIndex,
+  thumbSplitArr, thumbDisplayArr, setThumbDisplayArr, currentStyle,
 }) => (
   <div id="imagegallery-thumbnail-container">
     {(thumbSplitArr.length > 1)
@@ -16,7 +16,7 @@ const ImageGalleryThumbnail = ({
         <ImageGalleryThumbnailArrows
           currentImageIndex={currentImageIndex}
           setCurrentImageIndex={setCurrentImageIndex}
-          imageArray={imageArray}
+          currentStyle={currentStyle}
           thumbSplitArr={thumbSplitArr}
           setThumbDisplayArr={setThumbDisplayArr}
           thumbDisplayArr={thumbDisplayArr}
@@ -26,26 +26,24 @@ const ImageGalleryThumbnail = ({
     <div id="imagegallery-thumbnail-slide-container">
       {thumbSplitArr[thumbDisplayArr].map((style, idx) => (
         <React.Fragment key={idx}>
-          {(style.photos[0].url !== null)
+          {(style.thumbnlail_url !== null)
             ? (
               <div
                 id="imagegallery-thumbnail-slide-image"
-                key={style.photos[0].thumbnail_url + idx}
-                style={(style === imageArray[currentImageIndex]) ? { backgroundImage: `url(${style.photos[0].thumbnail_url})`, boxShadow: '0 0 0 3px white'} : { backgroundImage: `url(${style.photos[0].thumbnail_url})`}}
+                key={idx}
+                style={(idx === currentImageIndex) ? { backgroundImage: `url(${style.thumbnail_url})`, opacity: 1 } : { backgroundImage: `url(${style.thumbnail_url})` }}
                 alt=""
                 onClick={() => {
-                  setCurrentStyle(style);
                   setCurrentImageIndex(thumbDisplayArr * 7 + idx);
                 }}
               />
             ) : (
               <div
-                key={style.photos[0].thumbnail_url + idx}
+                key={idx}
                 id="imagegallery-thumbnail-slide-image"
-                style={(style === imageArray[currentImageIndex]) ? { backgroundImage: `url(${noImage})`, boxShadow: '0 0 0 3px white'} : { backgroundImage: `url(${noImage})`}}
+                style={(idx === currentImageIndex) ? { backgroundImage: `url(${noImage})`, opacity: 1 } : { backgroundImage: `url(${noImage})` }}
                 alt=""
                 onClick={() => {
-                  setCurrentStyle(style);
                   setCurrentImageIndex(thumbDisplayArr * 7 + idx);
                 }}
               />

--- a/client/components/Overview/components/ImageGallery/ImageGalleryThumbnail.jsx
+++ b/client/components/Overview/components/ImageGallery/ImageGalleryThumbnail.jsx
@@ -25,13 +25,13 @@ const ImageGalleryThumbnail = ({
       : null }
     <div id="imagegallery-thumbnail-slide-container">
       {thumbSplitArr[thumbDisplayArr].map((style, idx) => (
-        <>
+        <React.Fragment key={idx}>
           {(style.photos[0].url !== null)
             ? (
               <div
                 id="imagegallery-thumbnail-slide-image"
                 key={style.photos[0].thumbnail_url + idx}
-                style={{ backgroundImage: `url(${style.photos[0].thumbnail_url})` }}
+                style={(style === imageArray[currentImageIndex]) ? { backgroundImage: `url(${style.photos[0].thumbnail_url})`, boxShadow: '0 0 0 3px white'} : { backgroundImage: `url(${style.photos[0].thumbnail_url})`}}
                 alt=""
                 onClick={() => {
                   setCurrentStyle(style);
@@ -42,7 +42,7 @@ const ImageGalleryThumbnail = ({
               <div
                 key={style.photos[0].thumbnail_url + idx}
                 id="imagegallery-thumbnail-slide-image"
-                style={{ backgroundImage: `url(${noImage})` }}
+                style={(style === imageArray[currentImageIndex]) ? { backgroundImage: `url(${noImage})`, boxShadow: '0 0 0 3px white'} : { backgroundImage: `url(${noImage})`}}
                 alt=""
                 onClick={() => {
                   setCurrentStyle(style);
@@ -50,7 +50,7 @@ const ImageGalleryThumbnail = ({
                 }}
               />
             ) }
-        </>
+        </React.Fragment>
       ))}
     </div>
   </div>

--- a/client/components/Overview/components/ImageGalleryExpand/ImageGalleryArrowsExpanded.jsx
+++ b/client/components/Overview/components/ImageGalleryExpand/ImageGalleryArrowsExpanded.jsx
@@ -5,7 +5,7 @@ import leftArrow from '../../../../../public/static/leftarrow.png';
 import rightArrow from '../../../../../public/static/rightarrow.png';
 import '../../styles/ImageGalleryStyles.css';
 
-const ImageGalleryArrows = ({
+const ImageGalleryArrowsExpanded = ({
   currentImageIndex, setCurrentImageIndex, currentStyle,
 }) => (
   <div id="imagegallery-arrows-container">
@@ -14,4 +14,4 @@ const ImageGalleryArrows = ({
   </div>
 );
 
-export default ImageGalleryArrows;
+export default ImageGalleryArrowsExpanded;

--- a/client/components/Overview/components/ImageGalleryExpand/ImageGalleryExpand.jsx
+++ b/client/components/Overview/components/ImageGalleryExpand/ImageGalleryExpand.jsx
@@ -1,0 +1,28 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+import React from 'react';
+import '../../styles/ImageGalleryStyles.css';
+import ImageGalleryImageSlideExpanded from './ImageGalleryImageSlideExpanded';
+
+const ImageGalleryExpand = ({
+  currentImageIndex, setCurrentImageIndex, currentStyle,
+  setCurrentStyle, thumbSplitArr, thumbDisplayArr, setThumbDisplayArr, setOverviewModal,
+}) => (
+  <>
+    <div id="imagegallery-expanded-background" onClick={() => setOverviewModal(false)} />
+    <div id="imagegallery-expanded-container" style={{ height: window.innerHeight, width: window.innerHeight }}>
+      <ImageGalleryImageSlideExpanded
+        currentImageIndex={currentImageIndex}
+        setCurrentImageIndex={setCurrentImageIndex}
+        currentStyle={currentStyle}
+        setCurrentStyle={setCurrentStyle}
+        thumbDisplayArr={thumbDisplayArr}
+        thumbSplitArr={thumbSplitArr}
+        setThumbDisplayArr={setThumbDisplayArr}
+        setOverviewModal={setOverviewModal}
+      />
+    </div>
+  </>
+);
+
+export default ImageGalleryExpand;

--- a/client/components/Overview/components/ImageGalleryExpand/ImageGalleryExpandedZoom.jsx
+++ b/client/components/Overview/components/ImageGalleryExpand/ImageGalleryExpandedZoom.jsx
@@ -1,0 +1,16 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+import React from 'react';
+import '../../styles/ImageGalleryStyles.css';
+
+const ImageGalleryExpandedZoom = ({ currentStyle, currentImageIndex, setIsZoom }) => (
+  <div
+    id="imagegallery-extended-zoom-container"
+    style={{ backgroundImage: `url(${currentStyle.photos[currentImageIndex].url})` }}
+    onClick={() => setIsZoom(false)}
+  >
+    <div id="imagegallery-zoom-lens" />
+  </div>
+);
+
+export default ImageGalleryExpandedZoom;

--- a/client/components/Overview/components/ImageGalleryExpand/ImageGalleryImageSlideExpanded.jsx
+++ b/client/components/Overview/components/ImageGalleryExpand/ImageGalleryImageSlideExpanded.jsx
@@ -1,0 +1,64 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable react/no-array-index-key */
+import React, { useState } from 'react';
+import noImage from '../../../../../public/static/noimage.jpg';
+import '../../styles/ImageGalleryStyles.css';
+import ImageGalleryArrowsExpanded from './ImageGalleryArrowsExpanded';
+import ImageGalleryThumbnailExpanded from './ImageGalleryThumbnailExpanded';
+import ImageGalleryExpandedZoom from './ImageGalleryExpandedZoom';
+
+const ImageGalleryImageSlideExpanded = ({
+  setCurrentImageIndex, currentImageIndex, currentStyle, setCurrentStyle,
+  thumbSplitArr, thumbDisplayArr, setThumbDisplayArr, setOverviewModal,
+}) => {
+  const [isZoom, setIsZoom] = useState(false);
+  return (
+    <div id="imagegallery-expanded-mainimage-container">
+      {(isZoom) ? (
+        <ImageGalleryExpandedZoom
+          currentStyle={currentStyle}
+          currentImageIndex={currentImageIndex}
+          setIsZoom={setIsZoom}
+        />
+      ) : null }
+      <ImageGalleryArrowsExpanded
+        currentImageIndex={currentImageIndex}
+        setCurrentImageIndex={setCurrentImageIndex}
+        currentStyle={currentStyle}
+      />
+      <ImageGalleryThumbnailExpanded
+        currentImageIndex={currentImageIndex}
+        setCurrentImageIndex={setCurrentImageIndex}
+        setCurrentStyle={setCurrentStyle}
+        currentStyle={currentStyle}
+        thumbDisplayArr={thumbDisplayArr}
+        thumbSplitArr={thumbSplitArr}
+        setThumbDisplayArr={setThumbDisplayArr}
+      />
+      {currentStyle.photos.map((style, idx) => (
+        <React.Fragment key={idx}>
+          {(style.url !== null)
+            ? (
+              <div
+                id="imagegallery-expanded-slide-image"
+                key={idx}
+                style={idx === currentImageIndex ? { backgroundImage: `url(${style.url})`, opacity: 1, zIndex: 2 } : { backgroundImage: `url(${style.url})`, opacity: 0 }}
+                alt=""
+                onClick={() => setIsZoom(true)}
+              />
+            ) : (
+              <div
+                key={idx}
+                id="imagegallery-extended-slide-noimage"
+                style={idx === currentImageIndex ? { backgroundImage: `url(${noImage})`, opacity: 1, zIndex: 2 } : { backgroundImage: `url(${noImage})`, opacity: 0 }}
+                alt=""
+                onClick={() => setOverviewModal(true)}
+              />
+            ) }
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
+export default ImageGalleryImageSlideExpanded;

--- a/client/components/Overview/components/ImageGalleryExpand/ImageGalleryThumbnailArrowsExpanded.jsx
+++ b/client/components/Overview/components/ImageGalleryExpand/ImageGalleryThumbnailArrowsExpanded.jsx
@@ -1,0 +1,17 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+import React from 'react';
+import leftArrow from '../../../../../public/static/leftarrow.png';
+import rightArrow from '../../../../../public/static/rightarrow.png';
+import '../../styles/ImageGalleryStyles.css';
+
+const ImageGalleryThumbnailArrowsExpanded = ({
+  setThumbDisplayArr, thumbDisplayArr, thumbSplitArr,
+}) => (
+  <div id="imagegallery-thumbnail-arrows-container">
+    {thumbDisplayArr === 0 ? null : <img id="imagegallery-expanded-thumbnail-leftarrow" src={leftArrow} alt="" onClick={() => setThumbDisplayArr((thumbDisplayArr - 1))} />}
+    {thumbDisplayArr === thumbSplitArr.length - 1 ? null : <img id="imagegallery-expanded-thumbnail-rightarrow" src={rightArrow} alt="" onClick={() => setThumbDisplayArr((thumbDisplayArr + 1))} />}
+  </div>
+);
+
+export default ImageGalleryThumbnailArrowsExpanded;

--- a/client/components/Overview/components/ImageGalleryExpand/ImageGalleryThumbnailExpanded.jsx
+++ b/client/components/Overview/components/ImageGalleryExpand/ImageGalleryThumbnailExpanded.jsx
@@ -1,0 +1,45 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable react/no-array-index-key */
+import React from 'react';
+import ImageGalleryThumbnailArrowsExpanded from './ImageGalleryThumbnailArrowsExpanded';
+import '../../styles/ImageGalleryStyles.css';
+
+const ImageGalleryThumbnailExpanded = ({
+  currentImageIndex, setCurrentImageIndex, currentStyle,
+  thumbSplitArr, thumbDisplayArr, setThumbDisplayArr,
+}) => (
+  <div id="imagegallery-thumbnail-container">
+    {(thumbSplitArr.length > 1)
+      ? (
+        <ImageGalleryThumbnailArrowsExpanded
+          currentImageIndex={currentImageIndex}
+          setCurrentImageIndex={setCurrentImageIndex}
+          currentStyle={currentStyle}
+          thumbSplitArr={thumbSplitArr}
+          setThumbDisplayArr={setThumbDisplayArr}
+          thumbDisplayArr={thumbDisplayArr}
+        />
+      )
+      : null }
+    <div id="imagegallery-thumbnail-slide-container">
+      {thumbSplitArr[thumbDisplayArr].map((style, idx) => (
+        <React.Fragment key={idx}>
+          <div
+            id="imagegallery-extended-thumbnail-slide-image"
+            key={idx}
+            style={(style.url === currentStyle.photos[currentImageIndex].url)
+              ? { opacity: 1 } : null}
+            alt=""
+            onClick={() => {
+              setCurrentImageIndex(thumbDisplayArr * 7 + idx);
+            }}
+          />
+
+        </React.Fragment>
+      ))}
+    </div>
+  </div>
+);
+
+export default ImageGalleryThumbnailExpanded;

--- a/client/components/Overview/components/Styles.jsx
+++ b/client/components/Overview/components/Styles.jsx
@@ -14,18 +14,18 @@ const Styles = ({
   const getAllStyles = () => {
     axios.get('http://localhost:3000/api/getallstyles', { params: { id } })
       .then((results) => {
-        //  create an array with all styles (not in rows of 4)
-        setImageArray(results.data);
-        //  set the number of rows for thumbnail on main image
-        let numberOfRows = Math.ceil(results.data.length / 7);
-        //  split the thumbnails into n arrays of length 7
-        setThumbSplitArr([...Array(numberOfRows)]
-          .map((row, idx) => results.data
-            .slice(idx * 7, idx * 7 + 7)));
+        // //  create an array with all styles (not in rows of 4)
+        // setImageArray(results.data);
+        // //  set the number of rows for thumbnail on main image
+        // let numberOfRows = Math.ceil(results.data.length / 7);
+        // //  split the thumbnails into n arrays of length 7
+        // setThumbSplitArr([...Array(numberOfRows)]
+        //   .map((row, idx) => results.data
+        //     .slice(idx * 7, idx * 7 + 7)));
         //  makes the default style the first style
         setCurrentStyle(results.data[0]);
         // this will take all of the styles and seperate them into n arrays of length 4
-        numberOfRows = Math.ceil(results.data.length / 4);
+        const numberOfRows = Math.ceil(results.data.length / 4);
         setStyles([...Array(numberOfRows)]
           .map((row, idx) => results.data
             .slice(idx * 4, idx * 4 + 4)));

--- a/client/components/Overview/components/StylesRow.jsx
+++ b/client/components/Overview/components/StylesRow.jsx
@@ -13,8 +13,8 @@ import noimage from '../../../../public/static/noimage.jpg';
 //  if the style id is the current styles id add a shadow effect and make the checkmark visible
 //  onclick make the style clicked the new current style
 const StylesRow = ({
-  row, currentStyle, setCurrentStyle, setCurrentSize, rowidx, styles,
-  setCurrentQuantity, setAddToCartNoSize, setValue, setCurrentImageIndex,
+  row, currentStyle, setCurrentStyle, setCurrentSize,
+  setCurrentQuantity, setAddToCartNoSize, setValue,
 }) => (
   <div id="styles-row">
     {row.map((style, styleidx) => (
@@ -22,9 +22,10 @@ const StylesRow = ({
         <img
           id="check-img"
           onClick={() => {
-            setCurrentStyle(style);
-            setCurrentImageIndex(rowidx * 4 + styleidx)
+            // setCurrentImageIndex(rowidx * 4 + styleidx)
             LogClick('img', 'Overview');
+            setCurrentStyle(style);
+            (style !== currentStyle ? null : setCurrentStyle(style));
             (style === currentStyle ? null : setAddToCartNoSize(false));
             (style === currentStyle ? null : setCurrentSize(null));
             (style === currentStyle ? null : setCurrentQuantity(null));
@@ -40,13 +41,12 @@ const StylesRow = ({
             style={(style.style_id === currentStyle.style_id) ? { boxShadow: '0px 0px 5px 3px #888888' } : null}
             src={style.photos[0].thumbnail_url}
             onClick={() => {
-              setCurrentStyle(style);
-              // {console.log(styles[rowidx][styleidx])}
-              setCurrentImageIndex(rowidx * 4 + styleidx)
               LogClick('img', 'Overview');
+              setCurrentStyle(style);
               (style === currentStyle ? null : setAddToCartNoSize(false));
               (style === currentStyle ? null : setCurrentSize(null));
               (style === currentStyle ? null : setCurrentQuantity(null));
+              (style === currentStyle ? null : setValue('DEFAULT'));
             }}
             data-testid={style.name}
             alt=""
@@ -59,6 +59,7 @@ const StylesRow = ({
             onClick={() => {
               setCurrentStyle(style);
               LogClick('img', 'Overview');
+              (style !== currentStyle ? null : setCurrentStyle(style));
               (style === currentStyle ? null : setAddToCartNoSize(false));
               (style === currentStyle ? null : setCurrentSize(null));
               (style === currentStyle ? null : setCurrentQuantity(null));

--- a/client/components/Overview/styles/ImageGalleryStyles.css
+++ b/client/components/Overview/styles/ImageGalleryStyles.css
@@ -10,6 +10,7 @@
   background-size: cover;
   position: absolute;
   display: inline-block;
+  cursor: zoom-in;
 }
 
 #imagegallery-leftarrow {
@@ -19,6 +20,7 @@
   z-index: 3;
   top: 500px;
   left: 10px;
+  cursor: pointer;
 }
 
 #imagegallery-rightarrow {
@@ -28,6 +30,7 @@
   z-index: 3;
   top: 500px;
   right: 10px;
+  cursor: pointer;
 }
 
 #imagegallery-thumbnail-slide-container {
@@ -49,7 +52,9 @@
   display: inline-block;
   background-size: cover;
   padding: 3px;
-  box-shadow: 0 0 0 3px black
+  opacity: .5;
+  box-shadow: 0 0 0 1px white;
+  cursor: pointer;
 }
 
 #imagegallery-thumbnail-slide-image:hover {
@@ -63,6 +68,7 @@
   z-index: 4;
   bottom: 87px;
   left: 165px;
+  cursor: pointer;
 }
 
 #imagegallery-thumbnail-rightarrow {
@@ -72,4 +78,113 @@
   z-index: 4;
   bottom: 87px;
   right: 165px;
+  cursor: pointer;
+}
+
+#imagegallery-expanded-background{
+  width: 100%;
+  height: 100%;
+  background-color: black;
+  z-index: 10;
+  position: fixed;
+  opacity: .8;
+  padding: 0%;
+  margin: 0;
+  left: 0;
+  top: 0;
+}
+
+#imagegallery-expanded-container{
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: auto;
+  z-index: 15;
+  position: fixed;
+  background-color: white;
+}
+
+#imagegallery-expanded-mainimage-container{
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+#imagegallery-slide-image {
+  height: 100%;
+  width: 100%;
+  background-size: cover;
+  position: absolute;
+  display: inline-block;
+  cursor: zoom-in;
+}
+
+#imagegallery-expanded-slide-image {
+  height: 100%;
+  width: 100%;
+  background-size: cover;
+  position: absolute;
+  display: inline-block;
+  cursor: crosshair;
+}
+
+#imagegallery-extended-slide-noimage {
+  height: 100%;
+  width: 100%;
+  background-size: cover;
+  position: absolute;
+  display: inline-block;
+}
+
+
+#imagegallery-extended-thumbnail-slide-image {
+  position: relative;
+  margin: 10px;
+  width:20px;
+  height: 20px;
+  border-radius: 50px;
+  background-color: white;
+  z-index: 3;
+  display: inline-block;
+  background-size: cover;
+  padding: 3px;
+  opacity: .5;
+  box-shadow: 0 0 0 1px black;
+  cursor: pointer;
+}
+
+#imagegallery-extended-thumbnail-slide-image:hover {
+  opacity: .8;
+}
+
+#imagegallery-expanded-thumbnail-leftarrow{
+  position: absolute;
+  height: 30px;
+  width: 30px;
+  z-index: 4;
+  bottom: 72px;
+  left: 425px;
+  cursor: pointer;
+}
+
+#imagegallery-expanded-thumbnail-rightarrow{
+  position: absolute;
+  height: 30px;
+  width: 30px;
+  z-index: 4;
+  bottom: 72px;
+  right: 425px;
+  cursor: pointer;
+}
+
+#imagegallery-extended-zoom-container{
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  cursor: zoom-in;
+  z-index: 1000;
+  margin: auto;
+  cursor: grab;
+  background-size: cover;
 }

--- a/client/components/Overview/styles/ImageGalleryStyles.css
+++ b/client/components/Overview/styles/ImageGalleryStyles.css
@@ -49,21 +49,12 @@
   display: inline-block;
   background-size: cover;
   padding: 3px;
-  box-shadow: 0 0 0 2px white;
+  box-shadow: 0 0 0 3px black
 }
 
 #imagegallery-thumbnail-slide-image:hover {
   opacity: .8;
 }
-
-/* #imagegallery-thumbnail-arrows-container {
-  position: absolute;
-  height: 500px;
-  width: 500px;
-  z-index: 3;
-  width:100%;
-  height: 100%;
-} */
 
 #imagegallery-thumbnail-leftarrow {
   position: absolute;

--- a/server/index.js
+++ b/server/index.js
@@ -120,7 +120,7 @@ app.get('/api/getAllReviews', (req, res) => {
     });
 });
 
-//MARK REVIEW AS HELPFUL- updates a review to show it was found helpful 
+//MARK REVIEW AS HELPFUL- updates a review to show it was found helpful
 app.put('/api/reviews/:review_id/helpful', (req, res) => {
   //the request will have two values: the id of what to change and the +1 incremented value of the helpfulness review (on the client side)
   const { review_id } = req.params;


### PR DESCRIPTION
Image gallery can now expand and has all the functionality of the collapsed version. Zoomed image is not implemented in this iteration. A LOT of refactoring went into this one since I based my knowledge of style photos off the first product in our list. Turns out each style can have multiple photos that are different style to style. Realized this when my code was breaking. Fixed that issue in this PR.