### PR TITLE
Image gallery expanded

### DIFF
--- a/client/components/Overview/components/ImageGalleryExpand/ImageGalleryExpandedZoom.jsx
+++ b/client/components/Overview/components/ImageGalleryExpand/ImageGalleryExpandedZoom.jsx
@@ -1,16 +1,35 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable no-mixed-operators */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import React from 'react';
 import '../../styles/ImageGalleryStyles.css';
 
-const ImageGalleryExpandedZoom = ({ currentStyle, currentImageIndex, setIsZoom }) => (
-  <div
-    id="imagegallery-extended-zoom-container"
-    style={{ backgroundImage: `url(${currentStyle.photos[currentImageIndex].url})` }}
-    onClick={() => setIsZoom(false)}
-  >
-    <div id="imagegallery-zoom-lens" />
-  </div>
-);
+const ImageGalleryExpandedZoom = ({ currentStyle, currentImageIndex, setIsZoom }) => {
+  const mouseMove = (e) => {
+    const {
+      left, top, width, height,
+    } = e.target.getBoundingClientRect();
+    const x = (e.pageX - left) / width * 100;
+    const y = (e.pageY - top) / height * 100;
+    e.target.style.backgroundPosition = `-${x}% -${y}%`;
+  };
+
+  return (
+    <div
+      id="imagegallery-extended-zoom-container"
+      style={{
+        backgroundImage: `url(${currentStyle.photos[currentImageIndex].url})`,
+        height: 2.5 * window.innerHeight,
+        width: 2.5 * window.innerHeight,
+        backgroundPosition: '0% 0%',
+      }}
+      onMouseMove={mouseMove}
+      onClick={() => setIsZoom(false)}
+    >
+      <div id="imagegallery-zoom-lens" />
+    </div>
+  );
+};
 
 export default ImageGalleryExpandedZoom;

--- a/client/components/Overview/components/ImageGalleryExpand/ImageGalleryExpandedZoom.jsx
+++ b/client/components/Overview/components/ImageGalleryExpand/ImageGalleryExpandedZoom.jsx
@@ -2,17 +2,21 @@
 /* eslint-disable no-mixed-operators */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import React from 'react';
+import React, { useRef } from 'react';
 import '../../styles/ImageGalleryStyles.css';
 
 const ImageGalleryExpandedZoom = ({ currentStyle, currentImageIndex, setIsZoom }) => {
   const mouseMove = (e) => {
-    const {
-      left, top, width, height,
-    } = e.target.getBoundingClientRect();
-    const x = (e.pageX - left) / width * 100;
-    const y = (e.pageY - top) / height * 100;
-    e.target.style.backgroundPosition = `-${x}% -${y}%`;
+    //  get x and y positions of image
+    const imagePos = e.target.getBoundingClientRect();
+    //  find cursors x and y positions relative to image
+    let x = e.pageX - imagePos.left;
+    let y = e.pageY - imagePos.top;
+    //  if the user decides to scroll while in modal
+    x -= window.pageXOffset;
+    y -= window.pageYOffset;
+    //  update the display "window"
+    e.target.style.backgroundPosition = `-${1.5 * x}px -${1.5 * y}px`;
   };
 
   return (
@@ -26,9 +30,7 @@ const ImageGalleryExpandedZoom = ({ currentStyle, currentImageIndex, setIsZoom }
       }}
       onMouseMove={mouseMove}
       onClick={() => setIsZoom(false)}
-    >
-      <div id="imagegallery-zoom-lens" />
-    </div>
+    />
   );
 };
 

--- a/client/components/Overview/components/ImageGalleryExpand/ImageGalleryImageSlideExpanded.jsx
+++ b/client/components/Overview/components/ImageGalleryExpand/ImageGalleryImageSlideExpanded.jsx
@@ -40,13 +40,15 @@ const ImageGalleryImageSlideExpanded = ({
         <React.Fragment key={idx}>
           {(style.url !== null)
             ? (
-              <div
-                id="imagegallery-expanded-slide-image"
-                key={idx}
-                style={idx === currentImageIndex ? { backgroundImage: `url(${style.url})`, opacity: 1, zIndex: 2 } : { backgroundImage: `url(${style.url})`, opacity: 0 }}
-                alt=""
-                onClick={() => setIsZoom(true)}
-              />
+              <>
+                <div
+                  id="imagegallery-expanded-slide-image"
+                  key={idx}
+                  style={idx === currentImageIndex ? { backgroundImage: `url(${style.url})`, opacity: 1, zIndex: 2 } : { backgroundImage: `url(${style.url})`, opacity: 0 }}
+                  alt=""
+                  onClick={() => setIsZoom(true)}
+                />
+              </>
             ) : (
               <div
                 key={idx}

--- a/client/components/Overview/components/ImageGalleryExpand/ImageGalleryImageSlideExpanded.jsx
+++ b/client/components/Overview/components/ImageGalleryExpand/ImageGalleryImageSlideExpanded.jsx
@@ -10,7 +10,7 @@ import ImageGalleryExpandedZoom from './ImageGalleryExpandedZoom';
 
 const ImageGalleryImageSlideExpanded = ({
   setCurrentImageIndex, currentImageIndex, currentStyle, setCurrentStyle,
-  thumbSplitArr, thumbDisplayArr, setThumbDisplayArr, setOverviewModal,
+  thumbSplitArr, thumbDisplayArr, setThumbDisplayArr,
 }) => {
   const [isZoom, setIsZoom] = useState(false);
   return (
@@ -53,7 +53,6 @@ const ImageGalleryImageSlideExpanded = ({
                 id="imagegallery-extended-slide-noimage"
                 style={idx === currentImageIndex ? { backgroundImage: `url(${noImage})`, opacity: 1, zIndex: 2 } : { backgroundImage: `url(${noImage})`, opacity: 0 }}
                 alt=""
-                onClick={() => setOverviewModal(true)}
               />
             ) }
         </React.Fragment>

--- a/client/components/Overview/styles/ImageGalleryStyles.css
+++ b/client/components/Overview/styles/ImageGalleryStyles.css
@@ -187,4 +187,9 @@
   margin: auto;
   cursor: grab;
   background-size: cover;
+  background-repeat: no-repeat;
+}
+
+#imagegallery-expanded-mainimage-container{
+  overflow: hidden;
 }


### PR DESCRIPTION
Got the functionality of the image gallery expanded zoom working. Can enter the expanded image gallery and cycle through images just like the collapsed version. If you click on the expanded image in the gallery it will zoom in by 2.5 times and proportionally move (pain to implement) with the cursor. The only thing that needs to be changed/implemented still is that when in the zoomed window the cursor should be '-'. No tests written yet.